### PR TITLE
Upgrading some compiler plugins to allow cross compilation

### DIFF
--- a/src/main/scala/Compilation.scala
+++ b/src/main/scala/Compilation.scala
@@ -22,12 +22,12 @@ object Compilation {
       "Sonatype OSS Snapshots".at("https://oss.sonatype.org/content/repositories/snapshots")
     ),
     libraryDependencies ++= compilerPlugins ++ Seq(
-      "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided,
-      "org.scalacheck"  %% "scalacheck"   % "1.14.0"        % Test
+      "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full,
+      "org.scalacheck" %% "scalacheck"   % "1.14.0"        % Test
     )
   )
 
-  val silencerVersion = "1.4.1"
+  val silencerVersion = "1.4.4"
 
   // borrowed from https://tpolecat.github.io/2017/04/25/scalac-flags.html
   lazy val stdScalacOptions = Seq(
@@ -94,8 +94,8 @@ object Compilation {
   }
 
   val compilerPlugins = Seq(
-    compilerPlugin("org.typelevel"          %% "kind-projector"  % "0.10.3"),
+    compilerPlugin("org.typelevel"          %% "kind-projector"  % "0.11.0" cross CrossVersion.full),
     compilerPlugin("com.github.tomasmikula" %% "pascal"          % "0.3.5"),
-    compilerPlugin("com.github.ghik"        %% "silencer-plugin" % silencerVersion)
+    compilerPlugin("com.github.ghik"         % "silencer-plugin" % silencerVersion cross CrossVersion.full)
   )
 }

--- a/src/main/scala/Compilation.scala
+++ b/src/main/scala/Compilation.scala
@@ -7,8 +7,8 @@ object Compilation {
 
   val buildSettings =
     Seq(
-      scalaVersion := "2.12.8",
-      crossScalaVersions := Seq("2.11.12", "2.12.8", "2.13.0"),
+      scalaVersion := "2.12.10",
+      crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1"),
       scalacOptions ++= stdScalacOptions ++ crossScalacOptions.value,
       incOptions := incOptions.value.withLogRecompileOnMacro(false)
     )


### PR DESCRIPTION
I ran into some issues afer enabling cross compilation for scala `2.12.10` and `2.13.1` in `parserz` project so this PR is reflecting how I managed to get it - somehow - working after a bit of wrestling with the compilation plugins :face_with_head_bandage: :grin: 


Thanks for the feedback !

Note : the resulting plugin has been successfully tested against both `parserz` and `schemaz` projects :wink: 